### PR TITLE
SVCPLAN-2149: Fix calls to ncsa/sshd module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ gpfs::bindmounts::mountmap:
 
 ## Dependencies
 
+- https://github.com/ncsa/puppet-sshd
 - https://github.com/ncsa/puppet-spectrumscale
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,10 +22,10 @@ class profile_gpfs_client (
 
   $clean_hostlist = unique( [ $gpfs_master ] + $manager_hostlist )
 
-  ::ssh::allow_from{ 'profile::gpfs_client':
-    hostlist              => $clean_hostlist,
-    pam_access_users      => [root],
-    sshd_cfg_match_params => $params,
+  ::sshd::allow_from{ 'profile::gpfs_client':
+    hostlist                => $clean_hostlist,
+    users                   => [root],
+    additional_match_params => $params,
   }
 
   # DISABLE SETUID ON GPFS BINARIES


### PR DESCRIPTION
Port changes from https://ache-git.ncsa.illinois.edu/ache_puppet/mod/ncsa/puppet-profile_gpfs_client/-/compare/main...rundall%2FSVCPLAN-2149%2Fupdate_ssh_code to the parent module